### PR TITLE
RHMAP-16268 fix Angular Helloworld Quickstart doesn't have error object

### DIFF
--- a/www/app/controllers.js
+++ b/www/app/controllers.js
@@ -21,7 +21,7 @@ myApp.controller('MainCtrl', function($scope, $q, fhcloud) {
        */
       fhcloud('hello', { hello: userInput })
         .then(function(response){
-          // If successful, display the length  of the string.
+          // If successful, display the response.msg.
           if (response.msg !== null && typeof(response.msg) !== 'undefined') {
             $scope.noticeMessage = response.msg;
             $scope.textClassName = "text-success";
@@ -30,8 +30,8 @@ myApp.controller('MainCtrl', function($scope, $q, fhcloud) {
             $scope.textClassName = "text-danger";
           }
         })
-        .catch(function(msg, err){
-          //If the function
+        .catch(function(err){
+          // If the function encountered an error.
           $scope.noticeMessage = "$fh.cloud failed. Error: " + JSON.stringify(err);
           $scope.textClassName = "text-danger";
         });

--- a/www/app/modules/fhcloud.js
+++ b/www/app/modules/fhcloud.js
@@ -16,7 +16,7 @@ angular.module('fhcloud', [])
       timeout: 15000
     };
 
-    $fh.cloud(params, defer.resolve, defer.reject);
+    $fh.cloud(params, defer.resolve, function(msg,err){defer.reject(err);});
 
     return defer.promise;
   };


### PR DESCRIPTION
defer can only return one param, so it's only returning the message from $fh.cloud as it's the first parameter.
Make fhcloud module return the $fh.cloud error instead of the message as the error also contains the message