### PR TITLE
xcodebuild ios

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ node(platform) {
             archiveArtifacts artifacts: "platforms/android/build/outputs/apk/android-${BUILD_CONFIG}.apk", excludes: 'platforms/android/build/outputs/apk/*-unaligned.apk'
         }
         if (platform == 'ios') {
-            archiveArtifacts artifacts: "platforms/${platform}/build/${OSX_BUILD_CONFIG}-${SDK}/${OUTPUT_FILE_NAME}.ipa"
+            archiveArtifacts artifacts: "platforms/${platform}/build/${OSX_BUILD_CONFIG}-${SDK}/${OUTPUT_FILE_NAME}"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,18 @@ CODE_SIGN_PROFILE_ID = params?.BUILD_CREDENTIAL_ID?.trim()   // e.g. "redhat-dis
 /* ------------- use these to hardcode values in Jenkinsfile ---------------- */
 PROJECT_NAME = "QuickStart Angular"
 CLEAN = true                          // Do a clean build and sign
+INFO_PLIST = "${PROJECT_NAME}/${PROJECT_NAME}-Info.plist"
+VERSION = "1.0.0"
+SHORT_VERSION = "1.0"
+BUNDLE_ID = "org.feedhenry.dart.angular"
+OUTPUT_FILE_NAME="${PROJECT_NAME}-${BUILD_CONFIG}.ipa"
+SDK = "iphoneos"
 
+if (BUILD_CONFIG.toLowerCase() == "debug") {
+    OSX_BUILD_CONFIG = "Debug"
+} else if(BUILD_CONFIG.toLowerCase() == "release" || BUILD_CONFIG.toLowerCase() == "distribution") {
+    OSX_BUILD_CONFIG = "Release"
+}
 
 node(platform) {
     stage("Checkout") {
@@ -24,17 +35,37 @@ node(platform) {
     }
 
     stage("Prepare") {
+        sh 'npm install --production'
         sh "cordova platform rm ${platform}"
         sh "cordova platform add ${platform}"
         sh "cordova prepare ${platform}"
+        sh 'rm -rf node_modules'
     }
 
     stage("Build") {
+        if (platform == 'android') {
             if (BUILD_CONFIG == 'debug') {
                sh "cordova build ${platform} --debug"
             } else {
                sh "cordova build ${platform} --release"
             }
+        } else {
+            xcodeBuild(
+                cleanBeforeBuild: CLEAN,
+                src: "./platforms/${platform}",
+                schema: "${PROJECT_NAME}",
+                workspace: "${PROJECT_NAME}",
+                buildDir: "build",
+                sdk: "${SDK}",
+                version: "${VERSION}",
+                shortVersion: "${SHORT_VERSION}",
+                bundleId: "${BUNDLE_ID}",
+                infoPlistPath: "${INFO_PLIST}",
+                xcodeBuildArgs: 'ENABLE_BITCODE=NO OTHER_CFLAGS="-fstack-protector -fstack-protector-all"',
+                autoSign: false,
+                config: "${OSX_BUILD_CONFIG}"
+            )
+        }
     }
 
     stage("Sign") {
@@ -59,17 +90,17 @@ node(platform) {
                 profileId: "${CODE_SIGN_PROFILE_ID}",
                 clean: CLEAN,
                 verify: true,
-                appPath: "platforms/ios/build/emulator/${PROJECT_NAME}.app"
+                appPath: "platforms/${platform}/build/${OSX_BUILD_CONFIG}-${SDK}/${PROJECT_NAME}.app"
             )
         }
     }
 
     stage("Archive") {
         if (platform == 'android') {
-            archiveArtifacts artifacts: 'platforms/android/build/outputs/apk/android-${BUILD_CONFIG}.apk', excludes: 'platforms/android/build/outputs/apk/*-unaligned.apk'
+            archiveArtifacts artifacts: "platforms/android/build/outputs/apk/android-${BUILD_CONFIG}.apk", excludes: 'platforms/android/build/outputs/apk/*-unaligned.apk'
         }
         if (platform == 'ios') {
-            archiveArtifacts artifacts: "platforms/ios/build/emulator/${PROJECT_NAME}.ipa"
+            archiveArtifacts artifacts: "platforms/${platform}/build/${OSX_BUILD_CONFIG}-${SDK}/${PROJECT_NAME}.ipa"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ INFO_PLIST = "${PROJECT_NAME}/${PROJECT_NAME}-Info.plist"
 VERSION = "1.0.0"
 SHORT_VERSION = "1.0"
 BUNDLE_ID = "org.feedhenry.dart.angular"
-OUTPUT_FILE_NAME="${PROJECT_NAME}-${BUILD_CONFIG}.ipa"
+OUTPUT_FILE_NAME="${PROJECT_NAME}-${BUILD_CONFIG}.ipa".replace(" ", "").toLowerCase()
 SDK = "iphoneos"
 
 if (BUILD_CONFIG.toLowerCase() == "debug") {
@@ -90,6 +90,7 @@ node(platform) {
                 profileId: "${CODE_SIGN_PROFILE_ID}",
                 clean: CLEAN,
                 verify: true,
+                ipaName: OUTPUT_FILE_NAME,
                 appPath: "platforms/${platform}/build/${OSX_BUILD_CONFIG}-${SDK}/${PROJECT_NAME}.app"
             )
         }
@@ -100,7 +101,7 @@ node(platform) {
             archiveArtifacts artifacts: "platforms/android/build/outputs/apk/android-${BUILD_CONFIG}.apk", excludes: 'platforms/android/build/outputs/apk/*-unaligned.apk'
         }
         if (platform == 'ios') {
-            archiveArtifacts artifacts: "platforms/${platform}/build/${OSX_BUILD_CONFIG}-${SDK}/${PROJECT_NAME}.ipa"
+            archiveArtifacts artifacts: "platforms/${platform}/build/${OSX_BUILD_CONFIG}-${SDK}/${OUTPUT_FILE_NAME}.ipa"
         }
     }
 }


### PR DESCRIPTION
* installs npm packages before creating cordova app
* uses xcodebuild for ios apps instead of `cordova build`
* defines an ipa name to prevent blank space issues
